### PR TITLE
Clean up files after processing

### DIFF
--- a/DNSAuth/config.go
+++ b/DNSAuth/config.go
@@ -5,6 +5,8 @@ import (
 )
 
 type Config struct {
+	CleanupAction   string `cfg:"cleanup-action; none; /(none|move|delete)/; Action to take after processing a file"`
+	CleanupDir      string `cfg:"cleanup-dir; required; path; Path to move processed files when cleanup-action=move"`
 	CustomerDB      string `cfg:"customer-db; required; "`
 	CustomerRefresh int    `cfg:"customer-refresh; 24; "`
 	InfluxDB        string `cfg:"influx-db; required; "`

--- a/DNSAuth/dnsauth.toml
+++ b/DNSAuth/dnsauth.toml
@@ -9,3 +9,10 @@ influx-db = "http://127.0.0.1:8086/write?db=authdns"
 
 # The directory DNSAuth should watch for new log files coming in.
 watch-dir = "./"
+
+# Action to take after processing a file; one of none, move, or delete.
+cleanup-action = "none"
+
+# Path to move processed files when cleanup-action = "move".
+# Must not be a sub-directory of watch-dir; no trailing slash.
+cleanup-dir = "/tmp"

--- a/DNSAuth/main.go
+++ b/DNSAuth/main.go
@@ -244,7 +244,6 @@ func handleQuery(time time.Time, pop, line string) {
 
 func cleanupFile(filePath string, config *Config) error {
 	var err error
-	log.Printf("Cleaning up file %s. Action: %s", filePath, config.CleanupAction)
 	switch config.CleanupAction {
 	case "move":
 		err = cleanupFileMove(filePath, config.CleanupDir)
@@ -263,5 +262,6 @@ func cleanupFileMove(filePath string, destDir string) error {
 }
 
 func cleanupFileDelete(filePath string) error {
+	log.Printf("Removing file %s\n", filePath)
 	return os.Remove(filePath)
 }

--- a/DNSAuth/main.go
+++ b/DNSAuth/main.go
@@ -86,7 +86,7 @@ func main() {
 		if strings.HasSuffix(path, ".dmp.gz") {
 
 			if _, found := files[path]; !found {
-				go aggreagate(path, limiter, config)
+				go aggregate(path, limiter, config)
 				limiter <- true
 			}
 			newFiles[path] = true
@@ -115,7 +115,7 @@ func main() {
 	}
 }
 
-func aggreagate(filepath string, limiter chan bool, config *Config) {
+func aggregate(filepath string, limiter chan bool, config *Config) {
 
 	starttime := time.Now()
 

--- a/DNSAuth/main.go
+++ b/DNSAuth/main.go
@@ -115,13 +115,13 @@ func main() {
 	}
 }
 
-func aggregate(filepath string, limiter chan bool, config *Config) {
+func aggregate(filePath string, limiter chan bool, config *Config) {
 
 	starttime := time.Now()
 
 	defer func() { <-limiter }()
 
-	fileHandle, err := os.Open(filepath)
+	fileHandle, err := os.Open(filePath)
 	if err != nil {
 		log.Println(err)
 		return
@@ -130,21 +130,21 @@ func aggregate(filepath string, limiter chan bool, config *Config) {
 
 	reader, err := gzip.NewReader(fileHandle)
 	if err != nil {
-		log.Println(filepath, ": ", err)
+		log.Println(filePath, ": ", err)
 		return
 	}
 	defer reader.Close()
 
-	index := strings.LastIndex(filepath, "mon-") + len("mon-")
-	mon := filepath[index : index+2]
-	pop := filepath[index+3 : index+6]
+	index := strings.LastIndex(filePath, "mon-") + len("mon-")
+	mon := filePath[index : index+2]
+	pop := filePath[index+3 : index+6]
 
-	index = strings.LastIndex(filepath, "net_") + len("net_")
-	timestamp := filepath[index : index+16]
+	index = strings.LastIndex(filePath, "net_") + len("net_")
+	timestamp := filePath[index : index+16]
 
 	date, err := time.Parse(LAYOUT, timestamp)
 	if err != nil {
-		log.Println(filepath, ": ", err)
+		log.Println(filePath, ": ", err)
 		return
 	}
 
@@ -161,7 +161,7 @@ func aggregate(filepath string, limiter chan bool, config *Config) {
 
 		fields := strings.Fields(line)
 		if len(fields) != 9 {
-			log.Println("Issue unformatting line:", line, " for dump ", filepath)
+			log.Println("Issue unformatting line:", line, " for dump ", filePath)
 			continue
 		}
 		buffer.WriteString(line)
@@ -191,9 +191,9 @@ func aggregate(filepath string, limiter chan bool, config *Config) {
 		handleQuery(date.Truncate(time.Minute), pop, line)
 
 	}
-	err = cleanupFile(filepath, config)
+	err = cleanupFile(filePath, config)
 	if err != nil {
-		log.Printf("Failed to clean up %s. Reason: %s", filepath, err)
+		log.Printf("Failed to clean up %s. Reason: %s", filePath, err)
 	}
 	proctime := time.Since(starttime)
 	log.Printf("Processed dump [mon-%s-%s](%s - %s): %d lines in (%s) seconds!\n",

--- a/DNSAuth/main.go
+++ b/DNSAuth/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	flag.Parse()
 
-	log.Println("Loading config file...")
+	log.Printf("Loading config file %s...\n", *confpath)
 	config, err := LoadConfig(*confpath)
 	if err != nil {
 		log.Fatalln("FAILED: ", err)

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ influx-db = "http://127.0.0.1:8086/write?db=authdns"
 # The directory DNSAuth should watch for new log files coming in.
 watch-dir = "./"
 
+# Action to take after processing a file; one of none, move, or delete.
+cleanup-action = "none"
+
+# Path to move processed files when cleanup-action = "move".
+# Must not be a sub-directory of watch-dir; no trailing slash.
+cleanup-dir = "/tmp"
 ```
 
 DNSAuth ships with this file as displayed above.  During the set up steps below, you'll copy it to have a local copy which you can customize if needed.


### PR DESCRIPTION
This is the implementation of feature described in Packet-Clearing-House/DNSAuth#15. It adds a couple of configuration options to `dnsauth.toml` and implements associated logic to handle file cleanup after processing has been completed.

There are also a couple of code cleanup changes (in separate commits):
- renamed `aggreagate` to `aggregate`
- logged path of config file parsed at startup
- renamed variable `filepath` to avoid conflict with the package by the same name